### PR TITLE
Fix Max CR set to 0 not actually filtering

### DIFF
--- a/scripts/monsterfactory.js
+++ b/scripts/monsterfactory.js
@@ -223,11 +223,11 @@
 			}
 
 			if ( !args.skipCrCheck ) {
-				if ( filters.minCr && monster.cr.numeric < filters.minCr ) {
+				if ( (filters.minCr !== null) && monster.cr.numeric < filters.minCr ) {
 					return true;
 				}
 
-				if ( filters.maxCr && monster.cr.numeric > filters.maxCr ) {
+				if ( (filters.maxCr !== null) && monster.cr.numeric > filters.maxCr ) {
 					return true;
 				}
 			}


### PR DESCRIPTION
Part of [this issue](https://github.com/Asmor/5e-monsters/issues/189) from the original project.

Basically, setting Max CR to 0 doesn't currently work. This change lets the filter act as expected for people who might actually want to see only CR 0 monsters.

I also changed the Min CR logic to mirror it. This is not necessary - a false evaluation on the Min CR is handled the exact same as 0 since it's the floor anyway - but imo it keeps the logic more easily followable.